### PR TITLE
FORMS-25113: Show multiselect dropdown options as a scrollable visible list

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -21,3 +21,9 @@ select::after {
 .cmp-adaptiveform-dropdown__widget[multiple='multiple'] {
   height: 80px;
 }
+
+.cmp-adaptiveform-dropdown__widget[multiple] {
+  height: auto;
+  field-sizing: content;
+  max-height: 80px;
+}


### PR DESCRIPTION
## Problem

When a dropdown is configured as multiselect (`type: string[]`), the `<select>` element rendered with a fixed height that collapsed the list — making it difficult for users to see and pick from available options.

## Solution

- Added a CSS rule for `[multiple]` attribute (instead of `[multiple='multiple']`) using `field-sizing: content` and `height: auto` so the multiselect renders as an expanded visible list
- Capped with `max-height: 80px` to prevent taking up too much vertical space
- Single-select dropdowns are unaffected

## Test plan
- [ ] Multiselect dropdown renders as an expanded visible list
- [ ] Single-select dropdown behavior and appearance unchanged
- [ ] Existing styles remain intact

Fixes: [FORMS-25113](https://jira.corp.adobe.com/browse/FORMS-25113)
